### PR TITLE
Fixes to resolve conflicts in the requirements

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/numpy/numpy-stubs
+git+https://github.com/person594/numpy-stubs.git
 pycodestyle
 sphinx
 recommonmark

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "sklearn-crfsuite == 0.3.6",
         "nltk == 3.3",
         "networkx >= 2.2",
-        "spacy == 2.0.12",
+        "spacy >= 2.0.12",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
I had to fork the numpy-stubs repo due to versioning issues,
but now everything should work as described in the wiki without
any weird conflicting versions of numpy